### PR TITLE
Fix width and height for retina displays

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -37,8 +37,8 @@ class Carousel extends React.Component {
   updateFrameSize () {
     const { width, height } = getComputedStyle(this.refs.wrapper)
     this.setState({
-      frameWidth: parseInt(width.split('px')[0], 10),
-      frameHeight: parseInt(height.split('px')[0], 10)
+      frameWidth: parseFloat(width.split('px')[0]),
+      frameHeight: parseFloat(height.split('px')[0])
     })
   }
 


### PR DESCRIPTION
Heya, awesome project, had it up and running within no time. I work on a retina MacBook and I noticed other slides are slightly visible on the edges. This pull request uses parseFloat instead of parseInt so it allows for 'half' interface pixels for retina displays.