### PR TITLE
Allow props to derive state upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ All attributes are optional.
     </Carousel>
   }
   ```
+- `callback` {Function} Pass a function to your widget to allow state changes upstream when props update.
+  See an example here
+  ([callback example](src/callback-example.js)):
+
+  ```javascript
+  import Carousel from 're-carousel'
+  import Callback from './callback-example'
+  
+  setCallbackData = data => {
+    this.setState({callbackData: data})
+  }
+
+  export default function carousel () {
+    return <Carousel loop auto widgets={[Callback]} callback={this.setCallbackData}>
+      <div style={{backgroundColor: 'tomato', height: '100%'}}>Frame 1</div>
+      <div style={{backgroundColor: 'orange', height: '100%'}}>Frame 2</div>
+      <div style={{backgroundColor: 'orchid', height: '100%'}}>Frame 3</div>
+    </Carousel>
+  }
+  ```
 - `frames` {Array of ReactElement} If you want to create frames programmatically,
   use this attribute:
 

--- a/src/callback-example.js
+++ b/src/callback-example.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default class CallbackExample extends React.Component {
+  componentDidUpdate (prevProps) {
+    // Typical usage (don't forget to compare props):
+    if (this.props.index !== prevProps.index && this.props.index === this.props.total - 1) {
+      this.props.callback("We are at the end!")
+    }
+  }
+  render() {
+    return(<div>Hello, callback!</div>)
+  }
+}

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -344,7 +344,7 @@ class Carousel extends React.Component {
 
   render () {
     const { frames, current } = this.state
-    const { widgets, axis, loop, auto, interval } = this.props
+    const { widgets, axis, loop, auto, interval, callback } = this.props
     const wrapperStyle = objectAssign(styles.wrapper, this.props.style)
 
     return (
@@ -371,6 +371,7 @@ class Carousel extends React.Component {
               total={frames.length}
               prevHandler={this.prev}
               nextHandler={this.next}
+              callback={callback}
               axis={axis} loop={loop} auto={auto} interval={interval} />
           ))
         }
@@ -389,7 +390,8 @@ Carousel.propTypes = {
   frames: PropTypes.arrayOf(PropTypes.element),
   style: PropTypes.object,
   minMove: PropTypes.number,
-  onTransitionEnd: PropTypes.func
+  onTransitionEnd: PropTypes.func,
+  callback: PropTypes.func
 }
 
 Carousel.defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -3,16 +3,23 @@ import ReactDOM from 'react-dom'
 import Carousel from './carousel'
 import Dots from './indicator-dots'
 import Buttons from './buttons'
+import Callback from './callback-example'
 
 // Main App
 class App extends React.Component {
   constructor () {
     super()
     this.state = {
-      axis: 'x'
+      axis: 'x',
+      callbackData: null
     }
     this.setAxis = axis => {
       return () => this.setState({'axis': axis})
+    }
+    this.setCallbackData = data => {
+      this.setState({callbackData: data}, () => {
+        console.log("this.state.callbackData:", this.state.callbackData)
+      })
     }
   }
   render () {
@@ -24,7 +31,12 @@ class App extends React.Component {
           <span className={this.state.axis === 'y' ? 'axis current' : 'axis'}
             onClick={this.setAxis('y')}>vertical</span>
         </header>
-        <Carousel loop auto axis={this.state.axis} widgets={[Dots, Buttons]} className="custom-class">
+        <Carousel
+          auto
+          axis={this.state.axis}
+          widgets={[Dots, Buttons, Callback]}
+          callback={this.setCallbackData}
+          className="custom-class">
           <p style={{backgroundColor: 'royalblue', height: '100%'}}>FRAME 1</p>
           <p style={{backgroundColor: 'orange', height: '100%'}}>FRAME 2</p>
           <p style={{backgroundColor: 'orchid', height: '100%'}}>FRAME 3</p>


### PR DESCRIPTION
### What does this PR do?
Allows a widget to utilize carousel component props to derive state of an upstream component.

### Where should the reviewer start?
index.js

### Background context:
I made this mod because I wanted to detect when the carousel was at the last frame. In my use case, I enable a button once the user has advanced to the last frame, and I disable the button if they move to any other frame.

In order to accomplish this I introduce a new function prop to carousel.js called `callback` which can be accessed downstream by a widget. In this way, any props on the carousel component can be fed into the callback and executed upstream.