### PR TITLE
Clear debounceTimeoutId on componentWillUnmount

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -51,6 +51,7 @@ class Carousel extends React.Component {
   componentWillUnmount () {
     this.mounted = false
     this.clearAutoTimeout()
+    clearTimeout(this.debounceTimeoutId)
 
     this.refs.wrapper.removeEventListener('touchmove', this.onTouchMove, {capture: true})
     this.refs.wrapper.removeEventListener('touchend', this.onTouchEnd, {capture: true})


### PR DESCRIPTION
Due to the 25ms timeout there can be the case, that the components gets unmounted in this time frame.